### PR TITLE
Fixed octet compiling on mac using make file

### DIFF
--- a/octet/Makefile
+++ b/octet/Makefile
@@ -25,7 +25,7 @@ else
     endif
     ifeq ($(UNAME_S),Darwin)
         CC = clang
-        CCFLAGS += -g -O2 -Wswitch -D OCTET_MAC -F/System/Library/Frameworks -framework GLUT -framework OpenGL -framework OpenAL -lstdc++ -DOCTET_PREFIX=\"\" -Iopen_source/bullet
+        CCFLAGS += -g -O2 -Wswitch -D OCTET_MAC -F/System/Library/Frameworks -framework GLUT -framework OpenGL -framework OpenAL -lstdc++ -std=c++11 -DOCTET_PREFIX=\"\" -Iopen_source/bullet
     endif
 endif
 

--- a/octet/src/scene/mesh.h
+++ b/octet/src/scene/mesh.h
@@ -87,7 +87,7 @@ namespace octet { namespace scene {
 
     // add a new edge to a hash map. (index, index) -> (triangle+1, triangle+1)
     static void add_edge(dynarray<edge> &edges, unsigned tri_idx, unsigned i0, unsigned i1) {
-      edge e = { std::min(i0, i1), std::max(i0, i1), tri_idx, ~0 };
+      edge e = { static_cast<int32_t> (std::min(i0,i1)), static_cast<int32_t> (std::max(i0, i1)), static_cast<int32_t> (tri_idx), ~0 };
       edges.push_back(e);
     }
 

--- a/octet/src/scene/scene_node.h
+++ b/octet/src/scene/scene_node.h
@@ -346,7 +346,7 @@ namespace octet { namespace scene {
         btVector3 vel = rigid_body->getLinearVelocity();
         float s2 = vel.dot(vel);
         if (s2 > max_speed * max_speed) {
-          rigid_body->setLinearVelocity(vel * (max_speed/std::sqrt(s2)));
+          rigid_body->setLinearVelocity(vel * (max_speed/sqrt(s2)));
         }
       }
     #endif


### PR DESCRIPTION
-octet/MakeFile
Added std=c++11 for lambda usage

-octet/src/scene/mesh.h:
cast unsigned ints to int32_t to match for edge constructor

-octet/src/scene/scene_node.h
using sqrt instead of std::sqrt
(Compiler error:
“error: no member named 'sqrt' in namespace 'std'; did you mean simply
'sqrt’?”
)
